### PR TITLE
build: added a github workflow to verify contributors commits

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -69,7 +69,7 @@ jobs:
             For this to work the commit with commit hash: ${FIRST_COMMIT} should be an ancestor of HEAD
             but it seems this is not the case with the current HEAD.
 
-            Try rebasing to the develop branch of ockam.
+            Try rebasing to the develop branch of ockam-contributors
             https://github.com/build-trust/ockam-contributors/tree/develop
           " && exit 1)
 
@@ -88,7 +88,7 @@ jobs:
         env:
           PR_SENDER: ${{ github.event.pull_request.user.login }}
         run: |
-          unverified=$(cat commits.json | jq --raw-output '.[] | [.sha, .commit.verification.verified] | @csv' | grep false || echo '')
+          unverified=$(cat commits.json | jq --raw-output '.[] | select(.commit.verification.verified == false) | .sha')
 
           if [ -z "$unverified" ]; then
             echo '[✓] All commits in this pull request are Verified by Github.'

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -1,0 +1,163 @@
+name: All
+
+permissions:
+  contents: read
+
+on:
+  merge_group:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: Git commit sha, on which, to run this workflow
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  lint_commits:
+    name: All - lint_commits
+    runs-on: ubuntu-20.04
+
+    # We assume that commit 6a82a0c5c320f677adf23b13f3cc66ede031eb34 will be in the history
+    # of all commits based on ockam-contributors main branch
+    # https://github.com/build-trust/ockam-contributors/commit/6a82a0c5c320f677adf23b13f3cc66ede031eb34
+    env:
+      FIRST_COMMIT: 6a82a0c5c320f677adf23b13f3cc66ede031eb34
+
+    steps:
+      - name: Checkout
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
+        with:
+          fetch-depth: 0 # checkout full tree
+
+      - name: Checkout (Pull Request)
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
+        with:
+          fetch-depth: 0 # checkout full tree
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Get commit information from Github (Pull Request)
+        if: github.event_name == 'pull_request'
+        run: gh api repos/build-trust/ockam-contributors/pulls/${{ github.event.number }}/commits > commits.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set FIRST_COMMIT To Begin Linting (Pull Request)
+        if: github.event_name == 'pull_request'
+        run: |
+          pull_request_commits_length=$(cat commits.json | jq '. | length')
+          echo "Number of commits in pull requests are $pull_request_commits_length"
+          echo "FIRST_COMMIT=HEAD~${pull_request_commits_length}" >> $GITHUB_ENV
+
+      - name: Check FIRST_COMMIT is ancestor of HEAD
+        run: |
+          git merge-base --is-ancestor $FIRST_COMMIT HEAD || \
+          (echo "
+            This workflow checks that all commits follow the Ockam Commit Message Convention
+            https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages
+
+            We check all commits from HEAD backwards till the commit with commit hash: ${FIRST_COMMIT}.
+
+            ERROR:
+            For this to work the commit with commit hash: ${FIRST_COMMIT} should be an ancestor of HEAD
+            but it seems this is not the case with the current HEAD.
+
+            Try rebasing to the develop branch of ockam.
+            https://github.com/build-trust/ockam-contributors/tree/develop
+          " && exit 1)
+
+      - name: Check no merge commits
+        run: |
+          merge_commit_count=$(git rev-list --no-walk --count --merges $FIRST_COMMIT..HEAD)
+          if [ "$merge_commit_count" != "0" ]; then
+            echo "
+              Our main branch follows a linear history and cannot have merge commits.
+              Please rebase to main.
+            " && exit 1
+          fi
+
+      - name: Check all commits in are Verified by Github (Pull Request)
+        if: github.event_name == 'pull_request'
+        env:
+          PR_SENDER: ${{ github.event.pull_request.user.login }}
+        run: |
+          unverified=$(cat commits.json | jq --raw-output '.[] | [.sha, .commit.verification.verified] | @csv' | grep false || echo '')
+
+          if [ -z "$unverified" ]; then
+            echo '[✓] All commits in this pull request are Verified by Github.'
+          else
+            echo '
+              We require that all commits in a pull request are signed and Verified by Github
+
+              Please read about signing commits at:
+              https://docs.github.com/en/authentication/managing-commit-signature-verification
+
+              ERROR: The following commits are not Verified by Github.
+            '
+            echo "$unverified"
+            exit 1
+          fi
+
+      - name: Check added contributor
+        if: github.event_name == 'pull_request'
+        env:
+          PR_SENDER: ${{ github.event.pull_request.user.login }}
+        run: |
+          commits=$(git rev-list --reverse $FIRST_COMMIT..HEAD)
+          commits=($FIRST_COMMIT ${commits[@]})
+          
+          for commit in "${commits[@]}"
+          do
+            echo "\n---\nChecking commit: $commit"
+            
+            author_name=$(git show -s --format='%an' $commit)
+            author_email=$(git show -s --format='%ae' $commit)
+            
+            # check if this commit adds a line to the CONTRIBUTORS.csv file
+            added_contributor="$(git diff --unified=0 "$commit"^ $commit -- CONTRIBUTORS.csv | grep -E '^\+' | sed 's/^.\{1\}//' | tail -n 1)"
+            
+            # skip commits which don't add a contributor
+            if [ -z "$added_contributor" ]; then
+              echo "Commit ok!"
+              continue;
+            fi
+            
+            # now check that the provided data is consistent with the current commit
+            echo "Checking the added contributor"
+            IFS=',' read -r yes_no github_name full_name email_addresses <<< "$added_contributor"
+            
+            if [ "$yes_no" != "yes" ]; then
+              error="The line added to the contributors file must indicate a contributor agreement with 'yes'.\n  - got $yes_no"
+            fi
+            
+            if [ "$PR_SENDER" != "$github_name" ]; then
+              error="The github name added to the contributors file does not correspond to the github user who created the PR.\n  - got $github_name, expected $PR_SENDER"
+            fi
+            
+            if [ "$author_name" != "$full_name" ]; then
+              error="The name added to the CONTRIBUTORS.csv file must be the same as the author of current commit.\n  - got $full_name, expected $author_name"
+            fi
+            
+            if ! echo $email_addresses | grep -q "$author_email" ; then
+              error="The email address of the commit author is not part of the email addresses provided in the CONTRIBUTORS.csv file.\n  - got $email_addresses, expected $author_email"
+            fi
+            
+            if [ -n "$error" ]; then
+              printf "\n%b\n" "$error"
+            
+              echo "
+              The commit $commit is adding a new contributor to the list of contributors but there are some inconsistencies
+              between the provided information and the commit author. Please amend the commit to fix them.
+              "
+              exit 1
+            else
+              echo "Commit ok!"
+            fi
+          done


### PR DESCRIPTION
This is an attempt to automate the manual consistency checks currently done when a new contributor is added to the list of contributors. We check that:

 - there are no merge commits in the PR
 - the PR commits are signed
 - for the commit adding a contributor we check that
    - the agreement says 'yes' 
    - the commit author name is provided in the 'Github User'  column
    - the commit author full name is provided in the 'Name' column
    - the commit author email address is one of the addresses provided in the 'Emails' column