### PR TITLE
chore: Add SnowBiz to CONTRIBUTORS.csv

### DIFF
--- a/CONTRIBUTORS.csv
+++ b/CONTRIBUTORS.csv
@@ -234,3 +234,4 @@ yes,abhinavverma03,Abhinav Verma,<mudunuriabhi@gmail.com> <93146938+abhinavverma
 yes,bradlewis,Bradley Lewis,<bradley.lewis.dev@gmail.com> <22850972+BradLewis@users.noreply.github.com>
 yes,gautamprikshit1,Prikshit Gautam,<gautamprikshit1@gmail.com>
 yes,meysam81,Meysam,<MeysamAzad81@gmail.com>
+yes,SnowBiz,Alan Snow,<alan.snow@ockam.io> <mail@alansnow.dev>


### PR DESCRIPTION
Why: Adding my GitHub username as a contributor to Ockam Open Source projects.