### PR TITLE
chore: Add shanesveller's GitHub no-reply email

### DIFF
--- a/CONTRIBUTORS.csv
+++ b/CONTRIBUTORS.csv
@@ -203,7 +203,7 @@ yes,quasiuslikecautious,Zach Quasius,<zach@quasius.dev> <zquasius@gmail.com>
 yes,mehsalhi,Mehdi Salhi,<mehsalhi@proton.me> <mehdi.salhi@heig-vd.ch>
 yes,chanman3388,Chris Chan,<cwtchan3388@gmail.com>
 yes,amdadulbari,Md. Amdadul Bari Imad,<amdadulbari@gmail.com>
-yes,shanesveller,Shane Sveller,<shane.sveller@ockam.io> <shane@sveller.dev>
+yes,shanesveller,Shane Sveller,<shane.sveller@ockam.io> <shane@sveller.dev> <shanesveller@users.noreply.github.com>
 yes,aareet,Aareet Mahadevan,<aareet@users.noreply.github.com>
 yes,sergey-melnychuk,Sergey Melnychuk,<serg.meln@gmail.com>
 yes,itsajay1029,Ajay Chowdhury,<ajaychowdhury1029@gmail.com>


### PR DESCRIPTION
I use the "[Keep my email address private](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address#about-commit-email-addresses)" setting on my GitHub account, so merge commits and other commits created through the web UI do not use my committer email address.

This caused a build failure on our open-source repo: https://github.com/build-trust/ockam/actions/runs/5532943100/jobs/10095734039
